### PR TITLE
Remove deprecated signature param

### DIFF
--- a/generate_token.php
+++ b/generate_token.php
@@ -39,6 +39,8 @@ if (hash_equals($hmac, $computed_hmac)) {
 	// Store the access token
 	$result = json_decode($result, true);
 	$access_token = $result['access_token'];
+
+	// Show the access token (don't do this in production!)
 	echo $access_token;
 
 } else {

--- a/install.php
+++ b/install.php
@@ -1,7 +1,7 @@
 <?php
 
 // Set variables for our request
-$shop = "demo-shop";
+$shop = $_GET['shop'];
 $api_key = "1r30mrvCFMfq2DLGuIXyY2veEJVgTtDD";
 $scopes = "read_orders,write_products";
 $redirect_uri = "http://localhost/generate_token.php";


### PR DESCRIPTION
This PR removes the deprecated `signature` param (which was removed last year) and instead relies on `hmac` to compute the authenticity of the request.

Some other improvements:

* don't hardcode the shop name anywhere (instead rely on an incoming query parameter, this mimics how apps install from the Shopify App Store)
* use `hash_equals` rather than `===` for additional security vs. timing attacks
* use a more robust method for building the query string used to compute the digest (ensure `hmac` is computed using the entire payload less the `hmac` parameter itself, sort keys lexographically in the same manner that Shopify does)
* don't invoke `shopify_call()` inside of `generate_token.php`, as the request for obtaining the access token is not formed in the same manner as requests to the Shopify REST API (i.e. Content-Type is `x-www-form-encoded` vs. `application/json`)