### PR TITLE
Allow Shopify pagination header `Link` to be seen

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -53,7 +53,7 @@ function shopify_call($token, $shop, $api_endpoint, $query = array(), $method = 
 		array_shift($header_data); // Remove status, we've already set it above
 		foreach($header_data as $part) {
 			$h = explode(":", $part);
-			$headers[trim($h[0])] = trim($h[1]);
+			$headers[trim($h[0])] = trim(substr($part,strpos($part,':') + 1));
 		}
 
 		// Return headers and Shopify's response


### PR DESCRIPTION
If the header contains multiple colons the function strips the value

ex: with shopify's pagination on their products api `/admin/api/2019-10/products.json` they include the link to the next page in their header `Link` this link includes `https://<shopname>?page_key` which the current function will slice and remove the entire link leaving only `https` making this function unable to call the next pagination page